### PR TITLE
USER_CREATE setting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,9 @@ Optional settings::
     # list of default group names to assign to new users
     GOOGLEAUTH_GROUPS = []
 
+    # create new user if it doesn't exist, default True
+    GOOGLEAUTH_USER_CREATE = True
+
 URL routes
 ~~~~~~~~~~
 

--- a/googleauth/backends.py
+++ b/googleauth/backends.py
@@ -5,6 +5,7 @@ from django.contrib.auth.models import User, Group
 IS_STAFF = getattr(settings, 'GOOGLEAUTH_IS_STAFF', False)
 GROUPS = getattr(settings, 'GOOGLEAUTH_GROUPS', tuple())
 APPS_DOMAIN = getattr(settings, 'GOOGLEAUTH_APPS_DOMAIN', None)
+USER_CREATE = getattr(settings, 'GOOGLEAUTH_USER_CREATE', True)
 
 
 class GoogleAuthBackend(object):
@@ -28,6 +29,9 @@ class GoogleAuthBackend(object):
                 user = User.objects.get(username=username, email=email)
 
         except User.DoesNotExist:
+
+            if not USER_CREATE:
+                return None
 
             user = User.objects.create(username=username, email=email)
             user.first_name = attributes.get('first_name') or ''

--- a/googleauth/urls.py
+++ b/googleauth/urls.py
@@ -1,4 +1,8 @@
-from django.conf.urls import *
+try:
+    from django.conf.urls import *
+except:
+    # django 1.3
+    from django.conf.urls.defaults import *
 
 urlpatterns = patterns('',
     url(r'^login/$', 'googleauth.views.login', name='googleauth_login'),

--- a/googleauth/urls.py
+++ b/googleauth/urls.py
@@ -1,8 +1,8 @@
 try:
-    from django.conf.urls import *
+    from django.conf.urls import url, patterns
 except:
     # django 1.3
-    from django.conf.urls.defaults import *
+    from django.conf.urls.defaults import url, patterns
 
 urlpatterns = patterns('',
     url(r'^login/$', 'googleauth.views.login', name='googleauth_login'),


### PR DESCRIPTION
Hi Jeremy,
I needed the option to NOT create new user if it didn't exist for a project (as users were meant to be managed/created by different provider) so I've added the GOOGLEAUTH_USER_CREATE setting.

Feel free to pull it if you find it useful (and clean as well) :)

Thanks for the nice and very-easy-to-use package btw!
